### PR TITLE
Add large file upload support

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 dbrennand
+Copyright (c) 2022 dbrennand
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -254,5 +254,7 @@ To run the tests, perform the following steps:
 
 * [**dbrennand**](https://github.com/dbrennand) - *Author*
 
+* [**smk762**](https://github.com/smk762) - *Contributor*
+
 ## License
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ To run the tests, perform the following steps:
 
 ## Changelog
 
-* 0.2.0 - Added `large_file` parameter to `request` so a file larger than 32MB can be submitted for analysis. Thank you @smk762.
+* 0.2.0 - Added `large_file` parameter to `request` so a file larger than 32MB can be submitted for analysis. See [#33](https://github.com/dbrennand/virustotal-python/pull/33). Thank you @smk762.
 
 * 0.1.3 - Update urllib3 to 1.26.5 to address [CVE-2021-33503](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-33503).
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A Python library to interact with the public VirusTotal v2 and v3 APIs.
 > [!NOTE]
 >
 > This library is intended to be used with the public VirusTotal APIs. However, it *could* be used to interact with premium API endpoints as well.
+>
+> It is highly recommended that you use the VirusTotal v3 API as it is the "default and encouraged way to programmatically interact with VirusTotal".
 
 # Dependencies and installation
 
@@ -219,6 +221,8 @@ To run the tests, perform the following steps:
 3. From the root directory of the project run `pytest -s .\virustotal_python\tests.py`
 
 ## Changelog
+
+* 0.2.0 - Added `large_file` parameter to `request` so a file larger than 32MB can be submitted for analysis. Thank you @smk762.
 
 * 0.1.3 - Update urllib3 to 1.26.5 to address [CVE-2021-33503](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-33503).
 

--- a/examples/scan_file.py
+++ b/examples/scan_file.py
@@ -8,6 +8,8 @@ Documentation:
     * v2 documentation - https://developers.virustotal.com/reference#file-scan
 
     * v3 documentation - https://developers.virustotal.com/v3.0/reference#files-scan
+
+        * https://developers.virustotal.com/reference/files-upload-url
 """
 from virustotal_python import Virustotal
 import os.path
@@ -34,4 +36,15 @@ vtotal = Virustotal(API_KEY=API_KEY, API_VERSION="v3")
 
 resp = vtotal.request("files", files=files, method="POST")
 
+pprint(resp.data)
+
+# v3 example for uploading a file larger than 32MB in size
+vtotal = Virustotal(API_KEY=API_KEY, API_VERSION="v3")
+
+# Create dictionary containing the large file to send for multipart encoding upload
+large_file = {"file": (os.path.basename("/path/to/file/larger/than/32MB"), open(os.path.abspath("/path/to/file/larger/than/32MB"), "rb"))}
+# Get URL to send a large file
+upload_url = vtotal.request("files/upload_url").data
+# Submit large file to VirusTotal v3 API for analysis
+resp = vtotal.request(upload_url, files=large_file, method="POST", large_file=True)
 pprint(resp.data)

--- a/examples/scan_file.py
+++ b/examples/scan_file.py
@@ -42,7 +42,12 @@ pprint(resp.data)
 vtotal = Virustotal(API_KEY=API_KEY, API_VERSION="v3")
 
 # Create dictionary containing the large file to send for multipart encoding upload
-large_file = {"file": (os.path.basename("/path/to/file/larger/than/32MB"), open(os.path.abspath("/path/to/file/larger/than/32MB"), "rb"))}
+large_file = {
+    "file": (
+        os.path.basename("/path/to/file/larger/than/32MB"),
+        open(os.path.abspath("/path/to/file/larger/than/32MB"), "rb"),
+    )
+}
 # Get URL to send a large file
 upload_url = vtotal.request("files/upload_url").data
 # Submit large file to VirusTotal v3 API for analysis

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf8") as readme:
 
 setup(
     name="virustotal-python",
-    version="0.1.3",
+    version="0.2.0",
     author="dbrennand",
     description="A Python library to interact with the public VirusTotal v2 and v3 APIs.",
     long_description=long_description,

--- a/virustotal_python/__init__.py
+++ b/virustotal_python/__init__.py
@@ -1,2 +1,3 @@
 from virustotal_python.virustotal import Virustotal
+from virustotal_python.virustotal import VirustotalError
 name = "virustotal-python"

--- a/virustotal_python/tests.py
+++ b/virustotal_python/tests.py
@@ -1,6 +1,7 @@
 import virustotal_python
 import pytest
 import os.path
+import subprocess
 from time import sleep
 from base64 import urlsafe_b64encode
 
@@ -23,6 +24,29 @@ GRAPH_ID = "g70fae134aefc4e2f90f069aba47d15a92e0073564310443aa0b6ca3384f5240d"
 URL_DOMAIN = "google.com"
 # Example comment ID
 COMMENT_ID = "f-9f101483662fc071b7c10f81c64bb34491ca4a877191d464ff46fd94c7247115-07457619"
+
+
+@pytest.fixture()
+def large_file_fixture(request):
+    """Setup and teardown fixture for `test_large_file_v2` and `test_large_file_v3`."""
+    # Create a large file of 33MB to submit to the VirusTotal API for analysis
+    subprocess.run(
+        ["dd", "if=/dev/urandom", "of=dummy.dat", "bs=33M", "count=1"], check=True
+    )
+
+    def teardown():
+        """Delete the large file created by the fixture."""
+        subprocess.run(["rm", "dummy.dat"], check=True)
+
+    # Add finalizer function
+    request.addfinalizer(teardown)
+
+    return {
+        "file": (
+            os.path.basename("dummy.dat"),
+            open(os.path.abspath("dummy.dat"), "rb"),
+        )
+    }
 
 
 @pytest.fixture()
@@ -57,13 +81,6 @@ def test_file_scan_v2(vtotal_v2):
     """
     Test for sending a file to the VirusTotal v2 API for analysis.
     """
-    # Create dictionary containing the file to send for multipart encoding upload
-    files = {
-        "file": (
-            os.path.basename("virustotal_python/oldexamples.py"),
-            open(os.path.abspath("virustotal_python/oldexamples.py"), "rb"),
-        )
-    }
     resp = vtotal_v2.request("file/scan", files=FILES, method="POST")
     data = resp.json()
     assert resp.response_code == 1
@@ -322,3 +339,44 @@ def test_contextmanager_v3():
         assert data["id"] == IP
         assert data["attributes"]["as_owner"] == "GOOGLE"
         assert data["attributes"]["country"] == "US"
+
+
+@pytest.mark.largefile
+def test_large_file_v2(vtotal_v2, large_file_fixture):
+    """Test sending a large file to the VirusTotal v2 API for analysis.
+
+    https://developers.virustotal.com/v2.0/reference/file-scan-upload-url
+
+    NOTE: Currently this test does not work and returns a HTTP 500 internal server error.
+
+    Please see: https://github.com/dbrennand/virustotal-python/pull/33#issuecomment-1008307393
+    """
+    # Get URL to send large file
+    upload_url = vtotal_v2.request("file/scan/upload_url").json()["upload_url"]
+    # Expect VirustotalError due to HTTP 500 internal server error
+    with pytest.raises(virustotal_python.VirustotalError):
+        # Submit large file to VirusTotal v2 API for analysis
+        resp = vtotal_v2.request(
+            upload_url, files=large_file_fixture, method="POST", large_file=True
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["scan_id"]
+
+
+@pytest.mark.largefile
+def test_large_file_v3(vtotal_v3, large_file_fixture):
+    """Test sending a large file to the VirusTotal v3 API for analysis.
+
+    https://developers.virustotal.com/reference/files-upload-url
+    """
+    # Get URL to send large file
+    upload_url = vtotal_v3.request("files/upload_url").data
+    # Submit large file to VirusTotal v2 API for analysis
+    resp = vtotal_v3.request(
+        upload_url, files=large_file_fixture, method="POST", large_file=True
+    )
+    assert resp.status_code == 200
+    data = resp.data
+    assert data["id"]
+    assert data["type"] == "analysis"

--- a/virustotal_python/tests.py
+++ b/virustotal_python/tests.py
@@ -341,7 +341,6 @@ def test_contextmanager_v3():
         assert data["attributes"]["country"] == "US"
 
 
-@pytest.mark.largefile
 def test_large_file_v2(vtotal_v2, large_file_fixture):
     """Test sending a large file to the VirusTotal v2 API for analysis.
 
@@ -364,7 +363,6 @@ def test_large_file_v2(vtotal_v2, large_file_fixture):
         assert data["scan_id"]
 
 
-@pytest.mark.largefile
 def test_large_file_v3(vtotal_v3, large_file_fixture):
     """Test sending a large file to the VirusTotal v3 API for analysis.
 

--- a/virustotal_python/tests.py
+++ b/virustotal_python/tests.py
@@ -370,7 +370,7 @@ def test_large_file_v3(vtotal_v3, large_file_fixture):
     """
     # Get URL to send large file
     upload_url = vtotal_v3.request("files/upload_url").data
-    # Submit large file to VirusTotal v2 API for analysis
+    # Submit large file to VirusTotal v3 API for analysis
     resp = vtotal_v3.request(
         upload_url, files=large_file_fixture, method="POST", large_file=True
     )

--- a/virustotal_python/virustotal.py
+++ b/virustotal_python/virustotal.py
@@ -305,7 +305,7 @@ class Virustotal(object):
         :param json: A dictionary containing the JSON payload to send with the request.
         :param files: A dictionary containing the file for multipart encoding upload. (E.g: {'file': ('filename', open('filename.txt', 'rb'))})
         :param method: The request method to use.
-        :param large_file: If a file is larger than 32MB, a custom generated upload URL is required. 
+        :param large_file: If a file is larger than 32MB, a custom generated upload URL is required.
             If this param is set to `True`, this URL can be set via the resource param.
         :returns: A dictionary containing the HTTP response code (resp_code) and JSON response (json_resp) if self.COMPATIBILITY_ENABLED is True.
             Otherwise, a VirustotalResponse class object is returned. If a HTTP status not equal to 200 occurs. Then a VirustotalError class object is returned.
@@ -314,7 +314,7 @@ class Virustotal(object):
         # Create API endpoint
         endpoint = f"{self.BASEURL}{resource}"
         if large_file:
-            endpoint = f"{resource}"
+            endpoint = resource
         # If API version being used is v2, add the API key to params
         if self.API_VERSION == "v2":
             params["apikey"] = self.API_KEY

--- a/virustotal_python/virustotal.py
+++ b/virustotal_python/virustotal.py
@@ -305,6 +305,8 @@ class Virustotal(object):
         :param json: A dictionary containing the JSON payload to send with the request.
         :param files: A dictionary containing the file for multipart encoding upload. (E.g: {'file': ('filename', open('filename.txt', 'rb'))})
         :param method: The request method to use.
+        :param large_file: If a file is larger than 32MB, a custom generated upload URL is required. 
+            If this param is set to `True`, this URL can be set via the resource param.
         :returns: A dictionary containing the HTTP response code (resp_code) and JSON response (json_resp) if self.COMPATIBILITY_ENABLED is True.
             Otherwise, a VirustotalResponse class object is returned. If a HTTP status not equal to 200 occurs. Then a VirustotalError class object is returned.
         :raises Exception: Raise Exception when an unsupported method is provided.

--- a/virustotal_python/virustotal.py
+++ b/virustotal_python/virustotal.py
@@ -294,6 +294,7 @@ class Virustotal(object):
         json: dict = None,
         files: dict = None,
         method: str = "GET",
+        large_file: bool = False,
     ) -> Tuple[dict, VirustotalResponse]:
         """
         Make a request to the VirusTotal API.
@@ -310,6 +311,8 @@ class Virustotal(object):
         """
         # Create API endpoint
         endpoint = f"{self.BASEURL}{resource}"
+        if large_file:
+            endpoint = f"{resource}"
         # If API version being used is v2, add the API key to params
         if self.API_VERSION == "v2":
             params["apikey"] = self.API_KEY

--- a/virustotal_python/virustotal.py
+++ b/virustotal_python/virustotal.py
@@ -243,7 +243,7 @@ class Virustotal(object):
         :param TIMEOUT: A float for the amount of time to wait in seconds for the HTTP request before timing out.
         :raises ValueError: Raises ValueError when no API_KEY is provided or the API_VERSION is invalid.
         """
-        self.VERSION = "0.1.3"
+        self.VERSION = "0.2.0"
         if API_KEY is None:
             raise ValueError(
                 "An API key is required to interact with the VirusTotal API.\nProvide one to the API_KEY parameter or by setting the environment variable 'VIRUSTOTAL_API_KEY'."

--- a/virustotal_python/virustotal.py
+++ b/virustotal_python/virustotal.py
@@ -1,7 +1,7 @@
 """
 MIT License
 
-Copyright (c) 2021 dbrennand
+Copyright (c) 2022 dbrennand
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
I noticed that while using this package on large files it wouldn't work as expected, and found the reason to be related to https://developers.virustotal.com/reference/files-upload-url

This PR will allow for large file upload by setting a boolean param `large_file` and using a generated large file upload URL as the `resource` param. 

Example:

```python
# Get large file URL
r = vtotal.request("files/upload_url", method="GET")
upload_url = r.json()["data"]

# Upload a large file
files = {"file": (os.path.basename(file_with_path), open(os.path.abspath(file_with_path), "rb"))}
r = vtotal.request(upload_url, files=files, method="POST", large_file=True)
```

Real world example at https://github.com/smk762/draft_adex_release/blob/main/lib_virustotal.py#L26
